### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,23 +64,23 @@ _`Examples`
    :target: https://travis-ci.org/katakumpo/nicedjango
 .. |Coveralls| image:: https://coveralls.io/repos/katakumpo/nicedjango/badge.png?branch=master
    :target: https://coveralls.io/r/katakumpo/nicedjango?branch=master
-.. |Downloads| image:: https://pypip.in/download/nicedjango/badge.svg
+.. |Downloads| image:: https://img.shields.io/pypi/dm/nicedjango.svg
    :target: https://pypi.python.org/pypi/nicedjango/
-.. |Latest Version| image:: https://pypip.in/version/nicedjango/badge.svg
+.. |Latest Version| image:: https://img.shields.io/pypi/v/nicedjango.svg
    :target: https://pypi.python.org/pypi/nicedjango/
-.. |Supported Python versions| image:: https://pypip.in/py_versions/nicedjango/badge.svg
+.. |Supported Python versions| image:: https://img.shields.io/pypi/pyversions/nicedjango.svg
    :target: https://pypi.python.org/pypi/nicedjango/
-.. |Supported Python implementations| image:: https://pypip.in/implementation/nicedjango/badge.svg
+.. |Supported Python implementations| image:: https://img.shields.io/pypi/implementation/nicedjango.svg
    :target: https://pypi.python.org/pypi/nicedjango/
-.. |Development Status| image:: https://pypip.in/status/nicedjango/badge.svg
+.. |Development Status| image:: https://img.shields.io/pypi/status/nicedjango.svg
    :target: https://pypi.python.org/pypi/nicedjango/
-.. |Wheel Status| image:: https://pypip.in/wheel/nicedjango/badge.svg
+.. |Wheel Status| image:: https://img.shields.io/pypi/wheel/nicedjango.svg
    :target: https://pypi.python.org/pypi/nicedjango/
 .. |Egg Status| image:: https://pypip.in/egg/nicedjango/badge.svg
    :target: https://pypi.python.org/pypi/nicedjango/
-.. |Download format| image:: https://pypip.in/format/nicedjango/badge.svg
+.. |Download format| image:: https://img.shields.io/pypi/format/nicedjango.svg
    :target: https://pypi.python.org/pypi/nicedjango/
-.. |License| image:: https://pypip.in/license/nicedjango/badge.svg
+.. |License| image:: https://img.shields.io/pypi/l/nicedjango.svg
    :target: https://pypi.python.org/pypi/nicedjango/
 .. |Documentation Status| image:: https://readthedocs.org/projects/nicedjango-py/badge/?version=latest
    :target: https://nicedjango-py.readthedocs.org/en/latest/


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20nicedjango))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `nicedjango`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.